### PR TITLE
Specify weaker ciphers because of Java 7 regression

### DIFF
--- a/src/org/owasp/webscarab/plugin/proxy/ConnectionHandler.java
+++ b/src/org/owasp/webscarab/plugin/proxy/ConnectionHandler.java
@@ -319,6 +319,24 @@ public class ConnectionHandler implements Runnable {
 		try {
 			sslsock = (SSLSocket) factory.createSocket(sock, sock
 					.getInetAddress().getHostName(), sock.getPort(), true);
+			// Workaround for Java 7 regression: http://stackoverflow.com/q/10687200/427545
+			sslsock.setEnabledCipherSuites(new String[] {
+					"SSL_RSA_WITH_RC4_128_MD5",
+					"SSL_RSA_WITH_RC4_128_SHA",
+					"TLS_RSA_WITH_AES_128_CBC_SHA",
+					"TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+					"TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+					"SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+					"SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+					"SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+					"SSL_RSA_WITH_DES_CBC_SHA",
+					"SSL_DHE_RSA_WITH_DES_CBC_SHA",
+					"SSL_DHE_DSS_WITH_DES_CBC_SHA",
+					"SSL_RSA_EXPORT_WITH_RC4_40_MD5",
+					"SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
+					"SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
+					"SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
+					"TLS_EMPTY_RENEGOTIATION_INFO_SCSV"});
 			sslsock.setUseClientMode(false);
 			_logger.fine("Finished negotiating SSL - algorithm is "
 					+ sslsock.getSession().getCipherSuite());


### PR DESCRIPTION
Using OpenJDK 7u9_2.3.4 on Arch Linux, Webscarab failed with some clients.
Firefox 20 works fine, but subversion 1.7.8 fails with the stacktrace on the bottom of this post. I adapted the workaround from http://stackoverflow.com/a/11688235/427545. Since these are defaults from Java 6, it should not cause regressions with that. Granted, this is not a real fix for the underlying Java 7 issue and possibly should be reported at Oracle, but Oracle's bug tracker sucks.

```
javax.net.ssl.SSLException: Connection has been shutdown: javax.net.ssl.SSLException: java.security.ProviderException: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID
javax.net.ssl.SSLException: Connection has been shutdown: javax.net.ssl.SSLException: java.security.ProviderException: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID
        at sun.security.ssl.SSLSocketImpl.checkEOF(SSLSocketImpl.java:1492)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:92)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:69)
        at org.owasp.webscarab.model.Message.readLine(Message.java:440)
        at org.owasp.webscarab.model.Request.read(Request.java:98)
        at org.owasp.webscarab.plugin.proxy.ConnectionHandler.run(ConnectionHandler.java:186)
        at java.lang.Thread.run(Thread.java:722)
Caused by: javax.net.ssl.SSLException: java.security.ProviderException: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID
        at sun.security.ssl.Alerts.getSSLException(Alerts.java:208)
        at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1902)
        at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1860)
        at sun.security.ssl.SSLSocketImpl.handleException(SSLSocketImpl.java:1843)
        at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1362)
        at sun.security.ssl.SSLSocketImpl.getSession(SSLSocketImpl.java:2189)
        at org.owasp.webscarab.plugin.proxy.ConnectionHandler.negotiateSSL(ConnectionHandler.java:323)
        at org.owasp.webscarab.plugin.proxy.ConnectionHandler.run(ConnectionHandler.java:144)
        ... 1 more
Caused by: java.security.ProviderException: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID
        at sun.security.pkcs11.P11KeyPairGenerator.generateKeyPair(P11KeyPairGenerator.java:323)
        at java.security.KeyPairGenerator$Delegate.generateKeyPair(KeyPairGenerator.java:687)
        at sun.security.ssl.ECDHCrypt.<init>(ECDHCrypt.java:63)
        at sun.security.ssl.ServerHandshaker.setupEphemeralECDHKeys(ServerHandshaker.java:1206)
        at sun.security.ssl.ServerHandshaker.trySetCipherSuite(ServerHandshaker.java:1060)
        at sun.security.ssl.ServerHandshaker.chooseCipherSuite(ServerHandshaker.java:887)
        at sun.security.ssl.ServerHandshaker.clientHello(ServerHandshaker.java:620)
        at sun.security.ssl.ServerHandshaker.processMessage(ServerHandshaker.java:167)
        at sun.security.ssl.Handshaker.processLoop(Handshaker.java:868)
        at sun.security.ssl.Handshaker.process_record(Handshaker.java:804)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:1032)
        at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1328)
        at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1355)
        ... 4 more
Caused by: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID
        at sun.security.pkcs11.wrapper.PKCS11.C_GenerateKeyPair(Native Method)
        at sun.security.pkcs11.P11KeyPairGenerator.generateKeyPair(P11KeyPairGenerator.java:314)
        ... 16 more
```
