### PR TITLE
Do not consider an unused socket as expired

### DIFF
--- a/src/org/owasp/webscarab/httpclient/URLFetcher.java
+++ b/src/org/owasp/webscarab/httpclient/URLFetcher.java
@@ -481,6 +481,8 @@ public class URLFetcher implements HTTPClient {
         }
         _in = _socket.getInputStream();
         _out = _socket.getOutputStream();
+        // reset timeout
+        _lastRequestTime = System.currentTimeMillis();
     }
 
     private boolean useProxy(HttpUrl url) {


### PR DESCRIPTION
When a handshake is completed, `_lastRequestTime` is still 0. This
triggers a false timeout in `invalidSocket()` which checks for the the
difference between now and `_lastRequestTime`. As `_lastRequestTime`
equal to 0 means "do not re-use connection", reset the timer after
connecting rather than checking for `_lastRequestTime != 0` in
`invalidSocket()`.

Log:

```
15:50:28 Listener-0.0.0.0:8008-1(ConnectionHandler.run): Intercepting SSL connection!
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Opening a new connection
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Connect to localhost:4433
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Key fingerprint is null
15:50:28 Listener-0.0.0.0:8008-1(SSLContextManager.getSSLContext): Requested SSLContext for null
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Finished negotiating SSL
15:50:28 Listener-0.0.0.0:8008-1(Proxy.generateSocketFactory): Generating custom SSL keystore for localhost
15:50:28 Listener-0.0.0.0:8008-1(ConnectionHandler.negotiateSSL): Finished negotiating SSL - algorithm is TLS_RSA_WITH_AES_128_CBC_SHA
15:50:28 Listener-0.0.0.0:8008-1(ConnectionHandler.run): Reading request from the browser
15:50:28 Listener-0.0.0.0:8008-1(ConnectionHandler.run): Browser requested : GET https://localhost:4433/
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.invalidSocket): Socket has expired (1398606628553), open a new one!

15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Opening a new connection
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Connect to localhost:4433
15:50:28 Listener-0.0.0.0:8008-1(URLFetcher.connect): Key fingerprint is null
15:50:28 Listener-0.0.0.0:8008-1(SSLContextManager.getSSLContext): Requested SSLContext for null
```
