### PR TITLE
Fix ant warning because of deprecated File.toURL()

### DIFF
--- a/src/org/owasp/webscarab/Main.java
+++ b/src/org/owasp/webscarab/Main.java
@@ -42,7 +42,7 @@ public class Main {
 				findJars(f, urls);
 			} else {
 				try {
-					URL u = f.toURL();
+					URL u = f.toURI().toURL();
 					System.err.println("Adding " + u);
 					urls.add(u);
 				} catch (MalformedURLException mue) {


### PR DESCRIPTION
This fixes a compiler warning, because File.toURL() is deprecated.